### PR TITLE
Update to Ubuntu 16.04

### DIFF
--- a/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.10
+FROM ubuntu:16.04
 
 RUN apt-get -y update
 RUN apt-get -y install curl file gcc gcc-4.7-arm-linux-gnueabihf


### PR DESCRIPTION
Seems to work great here for hello_world. Hit some build issues with Serde v0.7.15 on Nightly, but that's not a platform issue ("expected slice, found struct `std::vec::Vec`"). Have to test it on some single board computers here, but the toolchain worked.

Thanks for making this project @alexcrichton. It was much easier to use this than rolling my own was. XD
